### PR TITLE
Add `hideComplexFunctions` option.

### DIFF
--- a/tasks/complexity.js
+++ b/tasks/complexity.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
 			errorsOnly: false,
 			cyclomatic: [3, 7, 12],
 			halstead: [8, 13, 20],
-			maintainability: 100
+			maintainability: 100,
+			hideComplexFunctions: false
 		},
 
 		normalizeOptions: function(options) {
@@ -96,11 +97,15 @@ module.exports = function(grunt) {
 		},
 
 		reportComplexity: function(reporter, analysis, filepath, options) {
-			var complicatedFunctions = analysis.functions.filter(function(data) {
-				return this.isComplicated(data, options);
-			}, this).map(function(data) {
-				return this.assignSeverity(data, options);
-			}, this);
+			var complicatedFunctions = [];
+
+			if (options.hideComplexFunctions !== true) {
+				complicatedFunctions = analysis.functions.filter(function(data) {
+					return this.isComplicated(data, options);
+				}, this).map(function(data) {
+					return this.assignSeverity(data, options);
+				}, this);
+			}
 
 			grunt.fail.errorcount += complicatedFunctions.length;
 


### PR DESCRIPTION
I've inherited a project with a lot of javascript files, most of then present really high complexity values.
When running the task, I always end up with too much information about the functions and I can't get to see the most problematic files among so much noise.

This commit adds just a simple option to disable the report of complex functions. I didn't change the default behaviour to avoid breaking other people's projects.

I'm uncertain about the quality of this commit, either in code style or usefulness, so feel free to propose corrections or reject it.
