### PR TITLE
Fix jshint issues

### DIFF
--- a/tasks/complexity.js
+++ b/tasks/complexity.js
@@ -151,7 +151,7 @@ module.exports = function(grunt) {
 
 		// Exclude any unwanted files from 'files' array
 		if (excludedFiles) {
-		    grunt.file.expand(excludedFiles).forEach(function (e) { files.splice(files.indexOf(e), 1); })
+			grunt.file.expand(excludedFiles).forEach(function (e) { files.splice(files.indexOf(e), 1); });
 		}
 
 		// Set defaults


### PR DESCRIPTION
Make `$ grunt jshint` stop barking and fixes some issues in `task/complexity.js`.
- fix missing semicolon in complexity task
- fix mixed tabs and spaces in complexity task
