### PR TITLE
Closes vigetlabs/grunt-complexity#20

### DIFF
--- a/tasks/complexity.js
+++ b/tasks/complexity.js
@@ -140,6 +140,11 @@ module.exports = function(grunt) {
 
 			files.map(function(filepath) {
 				var content = grunt.file.read(filepath);
+
+				if (!content.length) {
+					throw new Error('Empty source file: \'' + filepath + '\'.');
+				}
+
 				return {
 					filepath: filepath,
 					analysis: cr.run(content, options)

--- a/test/complexity-test.js
+++ b/test/complexity-test.js
@@ -15,6 +15,17 @@ describe("Complexity task", function() {
 		expect(normalized.halstead).to.eql([9]);
 	});
 
+	it ('throws an error when encountering an empty file', function () {
+		var targetFile = __dirname + '/fixtures/empty.js';
+		var reporter = {
+			start: function () {}
+		};
+
+		expect(function () {
+			cut.analyze(reporter, [targetFile], null);
+		}).to.throw('Empty source file: \'' + targetFile + '\'.');
+	});
+
 	describe("isComplicated", function() {
 		var data = {
 			complexity: {


### PR DESCRIPTION
Throw a more detailed error message in event of an empty source file is
encountered. Setting content=' ' will only mask the issue rather than
providing the user with feedback to take an appropriate action on the
file.

Error thrown will now return:

    Warning: Empty source file: 'src/routes/api.js'. Use --force to continue.

Added unit test and fixture for this corner case.