### PR TITLE
Only fail build on errors and allow lower severities to pass

### DIFF
--- a/complexity.json
+++ b/complexity.json
@@ -7,6 +7,7 @@
         "cyclomatic": 3,
         "halstead": 8,
         "maintainability": 100,
-        "broadcast": false
+        "broadcast": false,
+        "allowWarnings": true
     }
 }

--- a/tasks/complexity.js
+++ b/tasks/complexity.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
 			cyclomatic: [3, 7, 12],
 			halstead: [8, 13, 20],
 			maintainability: 100,
-			hideComplexFunctions: false
+			hideComplexFunctions: false,
+			allowWarnings: false
 		},
 
 		normalizeOptions: function(options) {
@@ -117,7 +118,11 @@ module.exports = function(grunt) {
 				}, this);
 			}
 
-			grunt.fail.errorcount += complicatedFunctions.length;
+			var errors = complicatedFunctions.filter(function(data){
+				return data.severity === "error";
+			});
+
+			grunt.fail.errorcount += (options.allowWarnings ? errors.length : complicatedFunctions.length);
 
 			reporter.complexity(filepath, complicatedFunctions);
 

--- a/test/eventReporter-test.js
+++ b/test/eventReporter-test.js
@@ -7,16 +7,16 @@ describe('Event Reporter', function() {
 
 	it ('triggers a maintainability event', function(done) {
 		var targetFile = __dirname + '/fixtures/sample.js';
-		var reporter   = Complexity.buildReporter([targetFile], { broadcast: true })
+		var reporter   = Complexity.buildReporter([targetFile], { broadcast: true });
 
 		grunt.event.on('grunt-complexity.maintainability', function(report) {
-			expect(report.filepath).to.equal(targetFile)
-			expect(report.valid).to.equal(true)
-			done()
-		})
+			expect(report.filepath).to.equal(targetFile);
+			expect(report.valid).to.equal(true);
+			done();
+		});
 
 		Complexity.analyze(reporter, [targetFile], Complexity.normalizeOptions({
 			maintainability: 0
-		}))
+		}));
 	});
 });


### PR DESCRIPTION
Add option so that complicated functions that have a lower severity than error will not fail the build.

I would have usually used a "breakOnlyOnError" type option instead of "allowWarnings", but both "breakError" and "errorsOnly" are already in use. Redefining those would cause backwards-compat issues, hence the slightly oddly named allowWarnings. Defaults to false to maintain existing behaviour.