### PR TITLE
--save vs --save-dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ to evaluate the complexity and maintainability of code.
 ## Usage
 
 ```bash
-npm install grunt-complexity --save
+npm install grunt-complexity --save-dev
 ```
 
 Within your grunt file:


### PR DESCRIPTION
Suggest running `npm install` with `--save-dev` instead of `--save`